### PR TITLE
Update deprecated tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [run]
 source = tlv


### PR DESCRIPTION
          ********************************************************************************
          Usage of dash-separated 'description-file' will not be supported in future
          versions. Please use the underscore name 'description_file' instead.
          (Affected: tlv8).
          Available configuration options are listed in:
          https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
          This deprecation is overdue, please update your project and remove deprecated
          calls to avoid build errors in the future.
          See https://github.com/pypa/setuptools/discussions/5011 for details.
          ********************************************************************************